### PR TITLE
Add automated walking path to pillars

### DIFF
--- a/etheria_login_click.py
+++ b/etheria_login_click.py
@@ -4,7 +4,9 @@ Etheria Helper — login / skip 可獨立執行（修正模板型別/通道不�
 用法：
   python etheria_login_click.py login   只做登入點擊
   python etheria_login_click.py skip    只做跳過
+  python etheria_login_click.py walk    走到石柱底下
   python etheria_login_click.py         先 login 再 skip
+  python etheria_login_click.py login skip walk  依序執行多段流程
 """
 
 import os, io, time, random, subprocess, sys, pathlib
@@ -37,6 +39,43 @@ MAX_RETRY_SKIP  = 10
 WAIT_AFTER_TAP  = 0.40
 TAP_JITTER_PX   = 5
 
+# ---------- 走到石柱 ----------
+PILLAR_TAP_SEQUENCE = [
+    {
+        "name": "center_align",
+        "target": (0.50, 0.70),
+        "taps": 2,
+        "timeout": 9.0,
+        "min_wait": 1.1,
+    },
+    {
+        "name": "left_pillar",
+        "target": (0.37, 0.44),
+        "taps": 2,
+        "timeout": 12.0,
+    },
+    {
+        "name": "between_pillars",
+        "target": (0.50, 0.42),
+        "taps": 1,
+        "timeout": 8.0,
+        "min_wait": 0.9,
+    },
+    {
+        "name": "right_pillar",
+        "target": (0.63, 0.44),
+        "taps": 2,
+        "timeout": 12.0,
+    },
+]
+
+PILLAR_TAP_GAP           = 0.35
+STABLE_CHECK_INTERVAL    = 0.45
+STABLE_MIN_WAIT          = 0.9
+STABLE_TIMEOUT           = 10.0
+STABLE_FRAMES_REQUIRED   = 3
+STABLE_DIFF_THRESHOLD    = 4.0
+
 # ---------- ADB ----------
 def adb(*args, timeout=20):
     cmd = [ADB_BIN, "-s", ADB_SERIAL] + list(args)
@@ -57,6 +96,54 @@ def keyevent(code): adb("shell", "input", "keyevent", str(code))
 def go_home():
     print("[FAILSAFE] BACK → HOME")
     keyevent(4); time.sleep(0.3); keyevent(3)
+
+
+def clamp(val, lo, hi):
+    return max(lo, min(hi, val))
+
+
+def multi_tap(x, y, times=1, gap=0.30):
+    times = max(1, int(times))
+    for i in range(times):
+        tap(x, y)
+        if i + 1 < times:
+            time.sleep(gap)
+
+
+def wait_until_stable(
+    timeout=STABLE_TIMEOUT,
+    min_wait=STABLE_MIN_WAIT,
+    check_interval=STABLE_CHECK_INTERVAL,
+    diff_threshold=STABLE_DIFF_THRESHOLD,
+    stable_frames=STABLE_FRAMES_REQUIRED,
+):
+    """偵測畫面平均亮度差是否持續低於門檻以判斷角色停止。"""
+    start = time.monotonic()
+    if min_wait > 0:
+        time.sleep(min_wait)
+
+    prev = None
+    stable = 0
+
+    while time.monotonic() - start < timeout:
+        img = screencap()
+        gray = cv.cvtColor(np.array(img), cv.COLOR_RGBA2GRAY)
+
+        if prev is not None:
+            diff = cv.absdiff(gray, prev)
+            score = float(np.mean(diff))
+            print(f"[STABLE] diff={score:.2f} (threshold={diff_threshold})")
+            if score < diff_threshold:
+                stable += 1
+                if stable >= stable_frames:
+                    return True
+            else:
+                stable = 0
+
+        prev = gray
+        time.sleep(check_interval)
+
+    return False
 
 # ---------- 影像工具（統一通道/型別） ----------
 def cv_imread_unicode(path: pathlib.Path):
@@ -182,17 +269,77 @@ def do_skip():
     go_home()
     return False
 
+
+def walk_to_pillars():
+    print("=== WALK TO PILLARS ===")
+    img = screencap()
+    sw, sh = img.size
+    steps = len(PILLAR_TAP_SEQUENCE)
+    all_ok = True
+
+    for idx, step in enumerate(PILLAR_TAP_SEQUENCE, 1):
+        name = step.get("name", f"step{idx}")
+        xf, yf = step.get("target", (0.5, 0.5))
+        taps = step.get("taps", 1)
+        timeout = step.get("timeout", STABLE_TIMEOUT)
+        min_wait = step.get("min_wait", STABLE_MIN_WAIT)
+        check_interval = step.get("check_interval", STABLE_CHECK_INTERVAL)
+        diff_threshold = step.get("diff_threshold", STABLE_DIFF_THRESHOLD)
+        stable_frames = step.get("stable_frames", STABLE_FRAMES_REQUIRED)
+
+        x = clamp(int(round(sw * xf)), 0, sw - 1)
+        y = clamp(int(round(sh * yf)), 0, sh - 1)
+
+        print(
+            f"[PILLAR] Step {idx}/{steps} '{name}': target=({xf:.3f},{yf:.3f}) → tap ({x},{y}) x{taps}"
+        )
+        multi_tap(x, y, times=taps, gap=PILLAR_TAP_GAP)
+
+        ok = wait_until_stable(
+            timeout=timeout,
+            min_wait=min_wait,
+            check_interval=check_interval,
+            diff_threshold=diff_threshold,
+            stable_frames=stable_frames,
+        )
+
+        if ok:
+            print(f"[PILLAR] {name}: 角色已停止")
+        else:
+            print(f"[WARN] {name}: 等待靜止逾時（繼續下一步）")
+            all_ok = False
+
+    if all_ok:
+        print("[OK] 兩側石柱走訪完成")
+    else:
+        print("[WARN] 石柱流程部分未確認，可視情況微調參數")
+
+    return all_ok
+
 # ---------- 主 ----------
 def main():
-    mode = (sys.argv[1].lower() if len(sys.argv) > 1 else "all")
-    if mode in ("login", "all"):
-        ok = do_login()
+    raw = [arg.lower() for arg in sys.argv[1:]]
+    if not raw:
+        raw = ["login", "skip"]
+
+    modes = []
+    for item in raw:
+        if item == "all":
+            modes.extend(["login", "skip"])
+        else:
+            modes.append(item)
+
+    for mode in modes:
         if mode == "login":
-            return
-        if not ok:
-            return
-    if mode in ("skip", "all"):
-        do_skip()
+            ok = do_login()
+            if not ok:
+                return
+        elif mode == "skip":
+            do_skip()
+        elif mode == "walk":
+            walk_to_pillars()
+        else:
+            print(f"[WARN] 未知模式：{mode}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add a configurable tap sequence and stability detection helpers to guide the character beneath the twin pillars
- expose a new `walk` mode and allow chaining multiple actions from the CLI entry point

## Testing
- python -m compileall etheria_login_click.py

------
https://chatgpt.com/codex/tasks/task_e_68c994e02d04832991491dcd93f23b41